### PR TITLE
format clock display correctly when beat's below 3 digits

### DIFF
--- a/sources/clock.js
+++ b/sources/clock.js
@@ -19,7 +19,7 @@ function Clock()
   {
     var t        = this.time();
     var t_s      = new String(t);
-    return {beat:t_s.substr(0,3),pulse:t_s.substr(3,3)};
+    return {beat:t_s.substr(0,(t_s.length-3)),pulse:t_s.substr(-3)};
   }
 
   this.toString = function()


### PR DESCRIPTION
when it's just past midnight, the clock wouldn't display beat and pulse correctly. 

e.g. instead of `1:234`, it shows `123:4`.

This is due to how the clock's time string is split - it was using first 3 characters as beats and whatever's after for pulse.

The bug fix uses first (length-3) characters as beats, and last 3 as pulse.