### PR TITLE
Basic win32 support

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,6 +1,6 @@
 const {app, Menu, Tray} = require('electron')
 const nativeImage = require('electron').nativeImage
-let image = nativeImage.createFromPath(app.getAppPath()+'/status.event.png') 
+let image = nativeImage.createFromPath(app.getAppPath()+'/status.event.png')
     image = image.resize({width:20,height:20})
 
 let clock     = require('./sources/clock')
@@ -8,15 +8,21 @@ let pomodoro  = require('./sources/pomodoro')
 let reminder  = require('./sources/reminder')
 let calendar  = require('./sources/calendar')
 
+const macos = process.platform == "darwin"
+
 app.on('ready', () => {
 
-  app.dock.hide()
+  if(macos){
+    app.dock.hide()
+  }
+
   app.status = "idle";
   this.decimal = true;
 
   this.tray = new Tray(image)
 
-  this.tray.on('right-click', () => { this.toggle_format(); this.update(); });
+  this.format_button = macos ? 'right-click' : 'click';
+  this.tray.on(this.format_button, () => { this.toggle_format(); this.update(); });
 
   reminder.add("stand",45)
   reminder.add("drink",30)
@@ -30,8 +36,8 @@ app.on('ready', () => {
 
   this.update = function()
   {
-    this.update_menu(); 
-    this.update_title(); 
+    this.update_menu();
+    this.update_title();
     this.update_status();
   }
 
@@ -80,7 +86,13 @@ app.on('ready', () => {
 
     if(prev_title != new_title){
       prev_title = new_title;
-      this.tray.setTitle(new_title)
+
+      if(macos){
+        this.tray.setTitle(new_title)
+      }
+      else {
+        this.tray.setToolTip(new_title)
+      }
     }
 
     this.update_status(new_status);
@@ -91,7 +103,7 @@ app.on('ready', () => {
     if(new_status != this.status){
       console.log("Status change:",new_status)
       this.status = new_status;
-      let image = nativeImage.createFromPath(app.getAppPath()+`/status.${this.status ? this.status : "idle"}.png`) 
+      let image = nativeImage.createFromPath(app.getAppPath()+`/status.${this.status ? this.status : "idle"}.png`)
       image = image.resize({width:20,height:20})
       this.tray.setImage(image);
     }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,14 +1,14 @@
 {
   "name": "Clock",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
-    "time":"node time.js",
-    "clean"        : "rm -r ~/Desktop/Clock-darwin-x64/ ; rm -r ~/Desktop/Clock-linux-x64/ ; rm -r ~/Desktop/Clock-win32-x64/ ; echo 'cleaned build location'",
-    "build_osx"    : "electron-packager . Clock --platform=darwin --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.icns ; echo 'Built for OSX'",
-    "build_linux"  : "electron-packager . Clock --platform=linux  --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.ico ; echo 'Built for LINUX'",
-    "build_win"    : "electron-packager . Clock --platform=win32  --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.ico ; echo 'Built for WIN'",
+    "start"        : "electron .",
+    "time"         : "node time.js",
+    "clean"        : "rm -r builds/Clock-darwin-x64/ ; builds/Clock-linux-x64/ ; builds/Clock-win32-x64/ ; echo 'cleaned build location'",
+    "build_osx"    : "electron-packager . Clock --platform=darwin --arch=x64 --out builds/ --overwrite --icon=icon.icns ; echo 'Built for OSX'",
+    "build_linux"  : "electron-packager . Clock --platform=linux  --arch=x64 --out builds/ --overwrite --icon=icon.ico ; echo 'Built for LINUX'",
+    "build_win"    : "electron-packager . Clock --platform=win32  --arch=x64 --out builds/ --overwrite --icon=icon.ico ; echo 'Built for WIN'",
     "build"        : "npm run clean ; npm run build_osx ; npm run build_linux ; npm run build_win"
   },
   "devDependencies": {


### PR DESCRIPTION
__Not tested on macOS !__ Make sure that it still works before merging.

## Regarding #2

- `app.dock` is not the only macOS only method used throughout the project, `Tray.setTitle` is macOS only as well.
- Neither [Tray](https://github.com/electron/electron/blob/master/docs/api/tray.md) nor [maxogden/menubar](https://github.com/maxogden/menubar) support displaying text on Windows taskbar notification area.

So, I've placed the title in a tooltip, shown when hovering with the mouse over the icon. Only on Windows, to avoid changing the previous behavior on macOS.

I've also found that on Windows, right clicking over the icon defaults to opening the menu, but this button was supposed to toggle decimal format. I've changed the format toggle button to left click on Windows.

## Screenshots

![2018-05-16_20-50-52](https://user-images.githubusercontent.com/2650578/40138574-65658646-594d-11e8-9fbf-e7b7bd8a4122.png)

![2018-05-16_20-51-33](https://user-images.githubusercontent.com/2650578/40138607-7926a05c-594d-11e8-8ab9-d8179398251c.png)

![2018-05-16_20-52-10](https://user-images.githubusercontent.com/2650578/40138612-7d1ec07c-594d-11e8-919f-8bdec0596a82.png)
