### PR TITLE
Fixed time calculation for times between 000:000 and 100:000.

### DIFF
--- a/desktop/sources/clock.js
+++ b/desktop/sources/clock.js
@@ -11,8 +11,9 @@ function Clock()
   {
     var d = new Date(), e = new Date(d);
     var msSinceMidnight = e - d.setHours(0,0,0,0);
-    var val = (msSinceMidnight/864) * 10;
-    return parseInt(val);
+    var val = msSinceMidnight / 8640 / 10000;
+    var format = val.toFixed(6).substr(2,6);
+    return format;
   }
 
   this.format = function()

--- a/mobile/sources/scripts/clock.js
+++ b/mobile/sources/scripts/clock.js
@@ -11,8 +11,9 @@ function Clock()
   {
     var d = new Date(), e = new Date(d);
     var msSinceMidnight = e - d.setHours(0,0,0,0);
-    var val = (msSinceMidnight/864) * 10;
-    return val;
+    var val = msSinceMidnight / 8640 / 10000;
+    var format = val.toFixed(6).substr(2,6);
+    return format;
   }
 
   this.format = function()

--- a/web/scripts/clock.js
+++ b/web/scripts/clock.js
@@ -11,9 +11,9 @@ function Clock()
   {
     var d = new Date(), e = new Date(d);
     var msSinceMidnight = e - d.setHours(0,0,0,0);
-    var val = (msSinceMidnight/864) * 10;
-    var format = val.toFixed(3).padStart(7,"0").replace(".","").substr(0,6)
-    return val;
+    var val = msSinceMidnight / 8640 / 10000;
+    var format = val.toFixed(6).substr(2,6);
+    return format;
   }
 
   this.format = function()


### PR DESCRIPTION
eg:
01:00 was 416:66 is now correctly 014:666
02:00 was 833:33 is now correctly 083:333

I have only tested the web version, but updated the desktop and mobile clock.js time functions to match. Desktop and mobile versions would need testing prior to merge.