### PR TITLE
Reminder notifications

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -28,7 +28,6 @@ app.on('ready', () => {
   reminder.add("stand",45)
   reminder.add("drink",30)
   reminder.add("rest",15)
-  reminder.add("test",2)
 
   this.toggle_format = function()
   {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,18 +3,19 @@
   "version": "0.1.1",
   "main": "main.js",
   "scripts": {
-    "start"        : "electron .",
-    "time"         : "node time.js",
-    "clean"        : "rm -r builds/Clock-darwin-x64/ ; builds/Clock-linux-x64/ ; builds/Clock-win32-x64/ ; echo 'cleaned build location'",
-    "build_osx"    : "electron-packager . Clock --platform=darwin --arch=x64 --out builds/ --overwrite --icon=icon.icns ; echo 'Built for OSX'",
-    "build_linux"  : "electron-packager . Clock --platform=linux  --arch=x64 --out builds/ --overwrite --icon=icon.ico ; echo 'Built for LINUX'",
-    "build_win"    : "electron-packager . Clock --platform=win32  --arch=x64 --out builds/ --overwrite --icon=icon.ico ; echo 'Built for WIN'",
-    "build"        : "npm run clean ; npm run build_osx ; npm run build_linux ; npm run build_win"
+    "start"       : "electron .",
+    "time"        : "node time.js",
+    "clean"       : "rm -r builds/Clock-darwin-x64/ builds/Clock-linux-x64/ builds/Clock-win32-x64/ ; echo 'cleaned build location'",
+    "build_osx"   : "electron-packager . Clock --platform=darwin --arch=x64 --out builds/ --overwrite --icon=icon.icns ; echo 'Built for OSX'",
+    "build_linux" : "electron-packager . Clock --platform=linux  --arch=x64 --out builds/ --overwrite --icon=icon.ico ; echo 'Built for LINUX'",
+    "build_win"   : "electron-packager . Clock --platform=win32  --arch=x64 --out builds/ --overwrite --icon=icon.ico ; echo 'Built for WIN'",
+    "build"       : "npm run clean ; npm run build_osx ; npm run build_linux ; npm run build_win"
   },
   "devDependencies": {
     "electron": "^1.8.1"
   },
   "dependencies": {
-    "electron-packager": "^8.4.0"
+    "electron-packager": "^8.4.0",
+    "node-notifier": "^5.2.1"
   }
 }

--- a/desktop/sources/reminder.js
+++ b/desktop/sources/reminder.js
@@ -1,6 +1,7 @@
 function Reminder()
 {
   this.scheduled = {};
+  this.mute = false;
 
   this.add = function(name,rate)
   {
@@ -16,6 +17,16 @@ function Reminder()
       }
     }
     return false;
+  }
+
+  this.toggle_mute = function()
+  {
+    this.mute = this.mute ? false : true;
+  }
+
+  this.menu = function(app)
+  {
+    return {label: 'Mute Reminders', type: 'checkbox', checked: this.mute, click:() => { this.toggle_mute(); app.update_menu(); } };
   }
 }
 


### PR DESCRIPTION
## Background

Last weekend I was diagnosed with scoliosis. Keep calm, it's on an early state, fixable, but I need to keep in mind getting off this chair every now and then, stretch the muscles and blah, blah, blah... As of right now I'm sitting here 1000/7.

So I thought: "how about notifications !? :)".

## Changes

- First of all, I've fixed some residual semicolons I left on `package.json` from my previous pull request... I'm sorry for that. It was greedy from me changing the build scripts like that, it's not my project. I've avoided changing the version number this time too, so it's up to you, @neauoire !
- I've added a new dependency: [node-notifier](https://www.npmjs.com/package/node-notifier). Electron comes with its own `Notification` API, but I've tested it and it doesn't work properly across platforms. `node-notifier` seems to work as intended and it comes with an easy to use API.
- There's a new option in the menu to mute notifications, just in case.
- I've also sorted the menu so it now displays different sections:
    - Calendar
    - Pomodoro
    - Settings
    - Quit

## Screenshots

![2018-05-24_18-09-05](https://user-images.githubusercontent.com/2650578/40497947-da04bedc-5f7d-11e8-923b-5a7f21845967.png)
